### PR TITLE
Add missing keyword identifiers

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -46,8 +46,8 @@ MIDI_CC	KEYWORD1
 #######################################
 refresh	KEYWORD2
 
-setDefault
-getDefault
+setDefault	KEYWORD2
+getDefault	KEYWORD2
 
 average	KEYWORD2
 map	KEYWORD2


### PR DESCRIPTION
The keywords are not recognized by the Arduino IDE for special highlighting without the identifiers.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keyword_tokentype